### PR TITLE
Remove new app model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,5 @@ WEBHOOK_SECRET=development
 # Subdomain to use for localtunnel server. Defaults to your local username.
 # SUBDOMAIN=
 
-SLACK_API_WORKSPACE_TEST_TOKEN=
-
 SLACK_VERIFICATION_TOKEN=
 OLD_MODEL_SLACK_TEST_TOKEN=

--- a/lib/issues.js
+++ b/lib/issues.js
@@ -2,7 +2,7 @@ const moment = require('moment');
 
 const WebClient = require('@slack/client').WebClient;
 
-const token = process.env.SLACK_API_WORKSPACE_TEST_TOKEN;
+const token = process.env.OLD_MODEL_SLACK_TEST_TOKEN;
 const web = new WebClient(token);
 
 const { arrayToFormattedString } = require('./helpers');

--- a/lib/pullRequests.js
+++ b/lib/pullRequests.js
@@ -2,7 +2,7 @@ const moment = require('moment');
 
 const WebClient = require('@slack/client').WebClient;
 
-const token = process.env.SLACK_API_WORKSPACE_TEST_TOKEN;
+const token = process.env.OLD_MODEL_SLACK_TEST_TOKEN;
 const web = new WebClient(token);
 
 const {


### PR DESCRIPTION
As part of this changeover, we will need to add the `chat:write:bot` scope to the old model app.

The permissions should be as below:
![image](https://user-images.githubusercontent.com/7718702/30976941-029893b2-a46e-11e7-9e1f-e7f97f1b6eca.png)

After adding this scope, we need to re-install the app.